### PR TITLE
accept generic options in Users.getFavorites()

### DIFF
--- a/src/structures/User.ts
+++ b/src/structures/User.ts
@@ -5,7 +5,8 @@ import type {
 	SearchUserFeedbackOptions,
 	CreateUserFeedbackOptions,
 	UserFeedbackProperties,
-	FeedbackCategories
+	FeedbackCategories,
+	GenericSearchOptions
 } from "../types";
 
 export default class User implements UserProperties {
@@ -76,9 +77,12 @@ export default class User implements UserProperties {
 	/**
 	 * Get this users favorites
 	 *
+	 * @param {object} [options]
+	 * @param {number} [options.page] - page of results to get
+	 * @param {number} [options.limit] - limit the maximum amount of results returned
 	 * @returns {Promise<Array<Post>>}
 	 */
-	async getFavorites() { return this.main.users.getFavorites(this.id); }
+	async getFavorites(options?: GenericSearchOptions) { return this.main.users.getFavorites({ id: this.id, ...options }); }
 
 	async asAuthenticatedUser() {
 		this.main.request.authCheck("User#asAuthenticatedUser");

--- a/src/types/users.d.ts
+++ b/src/types/users.d.ts
@@ -275,3 +275,7 @@ export interface EditSelfUserOptions {
 	disable_responsive_mode?: boolean;
 	custom_css_style?: string;
 }
+
+export interface GetFavoritesOptions extends GenericSearchOptions {
+	id?: number;
+}

--- a/test/users.ts
+++ b/test/users.ts
@@ -88,8 +88,20 @@ describe("Users", function() {
 	// @TODO Get Upload Limit Test
 	it.skip("get upload limit", async function() {});
 
-	// @TODO Get Favorites Test
-	it.skip("get favorites", async function() {});
+	it("get favorites", async function() {
+		const limit = 5;
+		const favorites = await E6Client.users.getFavorites({ id: 323290, limit });
+		expect(favorites.length).to.not.equal(0, "get favorites returned zero results");
+		expect(favorites.length).to.lte(limit, "get favorites not respecting limit");
+	});
+
+	it("get favorites from user object", async function() {
+		const limit = 5;
+		const user = await E6Client.users.get(323290);
+		const favorites = await user?.getFavorites({ limit }) || [];
+		expect(favorites.length).to.not.equal(0, "get favorites from user returned zero results");
+		expect(favorites.length).to.lte(limit, "get favorites not respecting limit");
+	});
 
 	// @TODO Add Favorite Test
 	it.skip("add favorite", async function() {});


### PR DESCRIPTION
adds `page` and `limit` to getFavorites(), making it possible to iterate through a user's favorites in the order they were added.